### PR TITLE
Fix docker image tag

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -16,13 +16,13 @@ build_steps:
     cmd: python3 setup.py test
   - desc: "Build Docker Image"  # The image should be buildable even if not uploaded
     cmd: |
-      docker build --build-arg BUILDER_VERSION=#{CDP_BUILD_VERSION} -t pierone.stups.zalan.do/bus/lizzy:#{CDP_BUILD_VERSION} .
+      docker build --build-arg BUILDER_VERSION=#{CDP_BUILD_VERSION} -t pierone.stups.zalan.do/bus/lizzy:cdp#{CDP_TARGET_BRANCH_COUNTER} .
   - desc: "Push Docker Image (if on master)"
     cmd: |
       IS_PR_BUILD=${CDP_PULL_REQUEST_NUMBER+"true"}
       if [[ $CDP_TARGET_BRANCH == "master" && ${IS_PR_BUILD} != "true" ]]
       then
-        docker push pierone.stups.zalan.do/bus/lizzy:#{CDP_BUILD_VERSION}
+        docker push pierone.stups.zalan.do/bus/lizzy:cdp#{CDP_TARGET_BRANCH_COUNTER}
       else
         echo "Image not pushed because the build is not a push to master"
       fi


### PR DESCRIPTION
Trying to deploy lizzy with senza using the latest tag returns the following error:

```
Error: Invalid value for "version": Version must satisfy regular expression pattern "[a-zA-Z0-9]+"
```

This is caused by the `-` in `master-5`, this PR generates a docker tag name without that character.