### PR TITLE
Push senza version to most recent one

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ environmental>=1.1
 decorator
 pytz
 pyyaml
-stups-senza>=1.0.40
+stups-senza>=2.1.77
 uwsgi
 flask==0.11.1
 metricz==0.1.4


### PR DESCRIPTION
It's been requiring a quite old version of stups-senza.