### PR TITLE
Account for user not being root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ EXPOSE 8080
 
 WORKDIR /app
 
+ENV PIPENV_VENV_IN_PROJECT true
+
 # We can't use / with pipenv https://github.com/pypa/pipenv/issues/1648
 COPY Pipfile.lock /app
 RUN pipenv install --ignore-pipfile


### PR DESCRIPTION
Running on taupage was failing because venv was created for root but lizzy was running as non root. This uses a .venv folder together with the code that doesn't vary by user.