### PR TITLE
Allegedly fix CDP build

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -4,6 +4,8 @@ pipeline:
     type: script
     overlay: ci/python
     commands:
+    - desc: "Setup OS packages"
+      cmd: apt-get install -y python-dev
     - desc: "Setup Pipenv"
       cmd: pipenv install --dev --deploy
     - desc: Run tests


### PR DESCRIPTION
Currently uwsgi compilation is failing because Python development headers are missing.