### PR TITLE
Match Python version when installing development headers

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -5,7 +5,7 @@ pipeline:
     overlay: ci/python
     commands:
     - desc: "Setup OS packages"
-      cmd: apt-get install -y python-dev
+      cmd: apt-get install -y python3-dev
     - desc: "Setup Pipenv"
       cmd: pipenv install --dev --deploy
     - desc: Run tests


### PR DESCRIPTION
A fix for https://github.com/zalando-stups/lizzy/pull/240